### PR TITLE
remove interface argument to Dev.read() call

### DIFF
--- a/ccsniffpiper.py
+++ b/ccsniffpiper.py
@@ -334,7 +334,7 @@ class CC2531:
     def recv(self):
 
         while self.running:
-            bytesteam = self.dev.read(CC2531.DATA_EP, 4096, 0, CC2531.DATA_TIMEOUT)
+            bytesteam = self.dev.read(CC2531.DATA_EP, 4096, timeout=CC2531.DATA_TIMEOUT)
 #             print "RECV>> %s" % binascii.hexlify(bytesteam)
 
             if len(bytesteam) >= 3:


### PR DESCRIPTION
The interface argument was removed at some point and is apparently
unneeded.

I also specified the timeout argument by name, so this will still work
with older versions of pyusb that still have the interface parameter.

This is identical to a8480b45 in pyCCSniffer.

This mirrors the change I made at https://github.com/andrewdodd/pyCCSniffer/pull/2.
