### PR TITLE
Improve Wireshark handling

### DIFF
--- a/99-cc2531-sniffer.rules
+++ b/99-cc2531-sniffer.rules
@@ -1,0 +1,2 @@
+# TI CC2531 sniffer
+ATTRS{idVendor}=="0451", ATTRS{idProduct}=="16ae", MODE="664", GROUP="plugdev"

--- a/ccsniffpiper.py
+++ b/ccsniffpiper.py
@@ -569,8 +569,11 @@ if __name__ == '__main__':
     try:
 
         while 1:
-            if args.headless is True and not snifferDev.isRunning():
-                snifferDev.start()
+            if args.headless is True:
+                if not snifferDev.isRunning():
+                    snifferDev.start()
+                # block until terminated (Ctrl+C or killed)
+                snifferDev.thread.join()
             else:
                 try:
                     if select.select([sys.stdin, ], [], [], 10.0)[0]:

--- a/ccsniffpiper.py
+++ b/ccsniffpiper.py
@@ -603,7 +603,7 @@ if __name__ == '__main__':
 #                        logger.debug('No user input')
                 except select.error:
                     logger.warn('Error while trying to read stdin')
-                except ValueError:
+                except ValueError as e:
                     print e
                 except UnboundLocalError:
                     # Raised by command 'n' when -o was specified at command line

--- a/pipe2wireshark.sh
+++ b/pipe2wireshark.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Usage: ./pipe2wireshark.sh CHANNEL
+#
+# If you get a USB permission error, please copy 99-cc2531-sniffer.rules to
+# /etc/udev/rules.d and reload udev or reboot.
+#
+# $ cp 99-cc2531-sniffer.rules /etc/udev/rules.d
+# $ sudo udevadm control --reload-rules
+# $ # otherwise reboot
+# $ sudo reboot
+
+# get channel or set default
+CHANNEL=$1
+if [ -z "$CHANNEL" ]; then
+    CHANNEL=26
+fi
+
+# start the sniffer and fork in background
+python ccsniffpiper.py -c $CHANNEL -d &
+SNIFFER_PID=$!
+
+# wait and check if it's still running (e.g. permission error)
+sleep 0.2
+if ! ps -p $SNIFFER_PID &> /dev/null; then
+    exit 1
+fi
+
+# install trap to kill sniffer when wireshark exits
+trap 'kill $SNIFFER_PID' EXIT
+
+# start wireshark immediately
+wireshark -k -i /tmp/ccsniffpiper


### PR DESCRIPTION
This PR adds 2 features:
* Restart capture in Wireshark, i.e. clear history
* A convenience script to start both sniffer and Wireshark together

Furthermore it fixes problems when running in headless mode in a non-interactive shell, i.e. from a script.